### PR TITLE
Update README to install torch==1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First, install [poetry](https://python-poetry.org/docs/):
 Use `poetry` to  install dependencies.  
 `poetry install`  
 
-`pytorch` is non-standard in the way it is packaged, and may need to be installed separately: `poetry run pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html`, however an entry in `pyproject.toml` is still needed.  
+`pytorch` is non-standard in the way it is packaged, and may need to be installed separately: `poetry run pip install torch===1.6.0+cpu torchvision===0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html`, however an entry in `pyproject.toml` is still needed.  
 
 Use `poetry` to install dependencies that were not installed due to the pytorch error.  
 `poetry install`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ Pillow = "^7.1.2"
 scholarly = "^0.3.3"
 seaborn = "^0.10.1"
 plotly = "^4.8.1"
-# torch = "1.5.1+cpu" # May need to be installed manually, but an entry here is necessary, too!
-# torchvision = "0.6.1+cpu"
+# torch = "1.6.0+cpu" # May need to be installed manually, but an entry here is necessary, too!
+# torchvision = "0.7.0+cpu"
 
 numpy = "^1.19.0"
 scipy = "1.4"


### PR DESCRIPTION
### Summary

Updates README to reflect the version of torch that poetry.lock contains. (torch==1.6.0)

### Backwards incompatibilities

None.

### New Dependencies

None.
